### PR TITLE
Source mode interface mocking improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ It supports the following flags:
  *  `-destination`: A file to which to write the resulting source code. If you
     don't set this, the code is printed to standard output.
 
- *  `-package`: The package to use for the resulting mock class
-    source code. If you don't set this, the package name is `mock_` concatenated
-    with the package of the input file.
+ *  `-package`: The package name to use for the resulting mock class source
+    code. If you don't set this, the package name is `mock_` concatenated with
+    the package of the input file.
 
  *  `-imports`: A list of explicit imports that should be used in the resulting
     source code, specified as a comma-separated list of elements of the form
@@ -68,6 +68,13 @@ It supports the following flags:
     specified as a comma-separated list of elements of the form
     `foo=bar/baz.go`, where `bar/baz.go` is the source file and `foo` is the
     package name of that file used by the -source file.
+
+ *  `-self_package`: The package this mock will be part of. Setting this
+    ensures that the package is not included in the imports.
+
+ *  `-source_package`: The package of the types in the source file. Setting
+    this ensures that types referenced by the interfaces in the source file
+    will be properly qualified.
 
 For an example of the use of `mockgen`, see the `sample/` directory. In simple
 cases, you will need only the `-source` flag.

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -215,7 +215,7 @@ func (p *fileParser) parseInterface(name, pkg string, it *ast.InterfaceType) (*m
 			intf.Methods = append(intf.Methods, m)
 		case *ast.Ident:
 			// Embedded interface in this package.
-			ei := p.auxInterfaces[""][v.String()]
+			ei := p.auxInterfaces[pkg][v.String()]
 			if ei == nil {
 				if ei = p.importedInterfaces[pkg][v.String()]; ei == nil {
 					return nil, p.errorf(v.Pos(), "unknown embedded interface %s", v.String())


### PR DESCRIPTION
- Support passing interfaces defined within the same package as the mock source as function arguments
- Support interface composition where interface is defined elsewhere in package

Example thing that wouldn't have worked before:

File: `mocktest.go`
```go
package mocktest

//go:generate mockgen -source mocktest.go -destination mock/mocktest.go -source_package github.turbine.com/bferullo/sandbox/mocktest -aux_files github.turbine.com/bferullo/sandbox/mocktest=other.go

// SameFileInterface is an interface defined in the file we're mocking
type SameFileInterface interface {
	DoSomethingInThisFile(x int) error
}

// FooBar will be mocked
type FooBar interface {
	OtherFileInterface
	SameFileInterface
	DoAThing(x SameFileInterface) error
	DoSomeOtherThing(x OtherFileInterface) error
}
```

File: `other.go`
```go
package mocktest

// OtherFileInterface is an interface defined in a file that isn't the one being mocked
type OtherFileInterface interface {
	DoSomethingInOtherFile() error
}
```

Resulting mock:
```go
// Automatically generated by MockGen. DO NOT EDIT!
// Source: mocktest.go

package mock_mocktest

import (
	gomock "github.com/golang/mock/gomock"
	mocktest "github.turbine.com/bferullo/sandbox/mocktest"
)

// Mock of SameFileInterface interface
type MockSameFileInterface struct {
	ctrl     *gomock.Controller
	recorder *_MockSameFileInterfaceRecorder
}

// Recorder for MockSameFileInterface (not exported)
type _MockSameFileInterfaceRecorder struct {
	mock *MockSameFileInterface
}

func NewMockSameFileInterface(ctrl *gomock.Controller) *MockSameFileInterface {
	mock := &MockSameFileInterface{ctrl: ctrl}
	mock.recorder = &_MockSameFileInterfaceRecorder{mock}
	return mock
}

func (_m *MockSameFileInterface) EXPECT() *_MockSameFileInterfaceRecorder {
	return _m.recorder
}

func (_m *MockSameFileInterface) DoSomethingInThisFile(x int) error {
	ret := _m.ctrl.Call(_m, "DoSomethingInThisFile", x)
	ret0, _ := ret[0].(error)
	return ret0
}

func (_mr *_MockSameFileInterfaceRecorder) DoSomethingInThisFile(arg0 interface{}) *gomock.Call {
	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoSomethingInThisFile", arg0)
}

// Mock of FooBar interface
type MockFooBar struct {
	ctrl     *gomock.Controller
	recorder *_MockFooBarRecorder
}

// Recorder for MockFooBar (not exported)
type _MockFooBarRecorder struct {
	mock *MockFooBar
}

func NewMockFooBar(ctrl *gomock.Controller) *MockFooBar {
	mock := &MockFooBar{ctrl: ctrl}
	mock.recorder = &_MockFooBarRecorder{mock}
	return mock
}

func (_m *MockFooBar) EXPECT() *_MockFooBarRecorder {
	return _m.recorder
}

func (_m *MockFooBar) DoSomethingInOtherFile() error {
	ret := _m.ctrl.Call(_m, "DoSomethingInOtherFile")
	ret0, _ := ret[0].(error)
	return ret0
}

func (_mr *_MockFooBarRecorder) DoSomethingInOtherFile() *gomock.Call {
	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoSomethingInOtherFile")
}

func (_m *MockFooBar) DoSomethingInThisFile(x int) error {
	ret := _m.ctrl.Call(_m, "DoSomethingInThisFile", x)
	ret0, _ := ret[0].(error)
	return ret0
}

func (_mr *_MockFooBarRecorder) DoSomethingInThisFile(arg0 interface{}) *gomock.Call {
	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoSomethingInThisFile", arg0)
}

func (_m *MockFooBar) DoAThing(x mocktest.SameFileInterface) error {
	ret := _m.ctrl.Call(_m, "DoAThing", x)
	ret0, _ := ret[0].(error)
	return ret0
}

func (_mr *_MockFooBarRecorder) DoAThing(arg0 interface{}) *gomock.Call {
	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoAThing", arg0)
}

func (_m *MockFooBar) DoSomeOtherThing(x mocktest.OtherFileInterface) error {
	ret := _m.ctrl.Call(_m, "DoSomeOtherThing", x)
	ret0, _ := ret[0].(error)
	return ret0
}

func (_mr *_MockFooBarRecorder) DoSomeOtherThing(arg0 interface{}) *gomock.Call {
	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoSomeOtherThing", arg0)
}

```